### PR TITLE
API rework.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,8 @@ pub struct ProjectInformation {
     pub information: Information,
     /// Specifies the external references of the VBA project.
     pub references: Vec<Reference>,
-    /// Specifies data for the modules in the project.
-    pub modules: Modules,
+    /// Specifies the modules in the project.
+    pub modules: Vec<Module>,
 }
 
 /// Specifies a reference to a twiddled type library and its extended type library.
@@ -128,21 +128,6 @@ pub struct Information {
     version_minor: u16,
     constants: String,
     constants_unicode: String,
-}
-
-/// Specifies data for the modules in the project.
-#[derive(Debug)]
-pub struct Modules {
-    /// An unsigned integer that specifies the number of elements in [`Modules::modules`].
-    ///
-    /// This value stores redundant information. It is populated by the parser and will
-    /// always agree with `modules.len()`. It is kept here to accurately represent the
-    /// raw binary contents.
-    pub count: u16,
-    /// Unused data. The value is populated by the parser but no longer used.
-    pub cookie: u16,
-    /// An array of [`Module`] records.
-    pub modules: Vec<Module>,
 }
 
 /// Specifies the containing module's type.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code)]
 
 use crate::{
-    Information, Module, ModuleType, Modules, ProjectInformation, Reference, ReferenceControl,
+    Information, Module, ModuleType, ProjectInformation, Reference, ReferenceControl,
     ReferenceOriginal, ReferenceProject, ReferenceRegistered, SysKind,
 };
 use codepage::to_encoding;
@@ -525,9 +525,10 @@ fn parse_module(i: &[u8], code_page: u16) -> IResult<&[u8], Module, FormatError<
     ))
 }
 
-fn parse_modules(i: &[u8], code_page: u16) -> IResult<&[u8], Modules, FormatError<&[u8]>> {
+fn parse_modules(i: &[u8], code_page: u16) -> IResult<&[u8], Vec<Module>, FormatError<&[u8]>> {
     let (i, count) = preceded(tuple((tag(&[0x0f, 0x00]), tag(U32_FIXED_SIZE_2))), le_u16)(i)?;
-    let (i, cookie) = preceded(tuple((tag(&[0x13, 0x00]), tag(U32_FIXED_SIZE_2))), le_u16)(i)?;
+    // Cookie MUST be ignored on read.
+    let (i, _cookie) = preceded(tuple((tag(&[0x13, 0x00]), tag(U32_FIXED_SIZE_2))), le_u16)(i)?;
 
     let mut modules = Vec::new();
     let mut i = i;
@@ -537,14 +538,7 @@ fn parse_modules(i: &[u8], code_page: u16) -> IResult<&[u8], Modules, FormatErro
         modules.push(module);
     }
 
-    Ok((
-        i,
-        Modules {
-            count,
-            cookie,
-            modules,
-        },
-    ))
+    Ok((i, modules))
 }
 
 // -------------------------------------------------------------------------


### PR DESCRIPTION
Removed the `Modules` struct altogether. The `count` member was redundant, and the `cookie` member unused. This is part of the effort to #8 streamline the API.