### PR TITLE
Added functions to extract source code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,25 @@ This library does not provide a way to extract the raw binary VBA project data f
 
 ## Usage
 
+Write out all modules' source code:
+
+```rust
+use ovba::{open_project, Result};
+use std::fs::{read, write};
+
+fn main() -> Result<()> {
+    let data = read("vbaProject.bin")?;
+    let project = open_project(data)?;
+
+    for module in &project.modules {
+        let src_code = project.module_source_raw(&module.name)?;
+        write("./out/".to_string() + &module.name, src_code)?;
+    }
+
+    Ok(())
+}
+```
+
 List all CFB entries contained in a VBA project:
 
 ```rust
@@ -34,27 +53,6 @@ fn main() -> Result<()> {
     // Iterate over CFB entries
     for (name, path) in project.list()? {
         println!(r#"Name: "{}"; Path: "{}""#, name, path);
-    }
-
-    Ok(())
-}
-```
-
-Write out all modules' source code:
-
-```rust
-use ovba::{open_project, Result};
-use std::fs::{read, write};
-
-fn main() -> Result<()> {
-    let data = read("vbaProject.bin")?;
-    let project = open_project(data)?;
-
-    for module in &project.modules {
-        let path = format!("/VBA\\{}", &module.stream_name);
-        let offset = module.text_offset;
-        let src_code = project.decompress_stream_from(&path, offset)?;
-        write("./out/".to_string() + &module.name, src_code)?;
     }
 
     Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,8 @@
 #![forbid(unsafe_code)]
 
-use std::error;
 use std::fmt;
 use std::io;
+use std::{error, string};
 
 /// A type alias for `Result<T, ovba::Error>`.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -20,9 +20,8 @@ pub enum Error {
     // TODO: Add details to make the diagnostic more meaningful to clients.
     /// Generic parsing error.
     Parser,
-    // TODO: Implement proper error handling. The module ovba should probably get its own error type.
-    /// Generic error.
-    Unknown,
+    /// Requested module cannot be found.
+    ModuleNotFound(string::String),
 }
 
 impl From<io::Error> for Error {
@@ -41,7 +40,7 @@ impl error::Error for Error {
             Error::Cfb(e) => Some(e),
             Error::Decompressor => None,
             Error::Parser => None,
-            Error::Unknown => None,
+            Error::ModuleNotFound(_) => None,
         }
     }
 }
@@ -53,7 +52,7 @@ impl fmt::Display for Error {
             Error::Cfb(e) => write!(f, "CFB error: {}", e),
             Error::Decompressor => write!(f, "Decompressor error"),
             Error::Parser => write!(f, "Parse error"),
-            Error::Unknown => write!(f, "Generic error"),
+            Error::ModuleNotFound(name) => write!(f, r#"Module "{}" not found"#, name),
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -635,7 +635,7 @@ pub(crate) fn parse_project_information(
 /// This is a temporary solution that allows me to postpone implementing error reporting
 /// to a later time, when the set of expected errors and the overall error handling strategy
 /// are better understood.
-fn cp_to_string(data: &[u8], code_page: u16) -> String {
+pub(crate) fn cp_to_string(data: &[u8], code_page: u16) -> String {
     let encoding = to_encoding(code_page).expect("Failed to map code page to an encoding.");
     let mut decoder = encoding.new_decoder_without_bom_handling();
     // The following returns `None` on overflow. That case is only expected with malformed document


### PR DESCRIPTION
* Provided both raw as well as UTF-8 implementations.
* Removed unused error::Error enum.
* Restructured README/lib doc to list the primary use case first.