### PR TITLE
Parser: read optional PROJECTCOMPATVERSION Record.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,7 @@ pub enum Reference {
 pub struct Information {
     /// Specifies the platform for which the VBA project is created.
     pub sys_kind: SysKind,
+    compat: Option<u32>,
     lcid: u32,
     lcid_invoke: u32,
     /// Specifies the code page for the VBA project.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -164,6 +164,15 @@ fn parse_syskind(i: &[u8]) -> IResult<&[u8], SysKind, FormatError<&[u8]>> {
     }
 }
 
+fn parse_compat(i: &[u8]) -> IResult<&[u8], Option<u32>, FormatError<&[u8]>> {
+    const COMPAT_SIGNATURE: &[u8] = &[0x4A, 0x00];
+    let (i, compat) = opt(preceded(
+        tuple((tag(COMPAT_SIGNATURE), tag(U32_FIXED_SIZE_4))),
+        le_u32,
+    ))(i)?;
+    Ok((i, compat))
+}
+
 fn parse_lcid(i: &[u8]) -> IResult<&[u8], u32, FormatError<&[u8]>> {
     const LCID_SIGNATURE: &[u8] = &[0x02, 0x00];
     let (i, lcid) = preceded(tuple((tag(LCID_SIGNATURE), tag(U32_FIXED_SIZE_4))), le_u32)(i)?;
@@ -562,6 +571,7 @@ pub(crate) fn parse_project_information(
     i: &[u8],
 ) -> IResult<&[u8], ProjectInformation, FormatError<&[u8]>> {
     let (i, sys_kind) = parse_syskind(i)?;
+    let (i, compat) = parse_compat(i)?;
     let (i, lcid) = parse_lcid(i)?;
     let (i, lcid_invoke) = parse_lcid_invoke(i)?;
     let (i, code_page) = parse_code_page(i)?;
@@ -619,6 +629,7 @@ pub(crate) fn parse_project_information(
         ProjectInformation {
             information: Information {
                 sys_kind,
+                compat,
                 lcid,
                 lcid_invoke,
                 code_page,


### PR DESCRIPTION
Hi @tim-weis ,

I'm the author of an R package to create and modify Office Open XML files and have written various not so safe C++ parsers, including one for the XLSB format. Yesterday I tried to look into the `vbaProject.bin` file and came across your `ovba` project. I tried to embed it in an R package, but had no luck. Given that I have no prior knowledge of either rust development or rust development in R, this didn't surprise me. Still I tried to toy around with it and this toying around results in this PR. But as stated, until yesterday I hadn't written a single line of rust code. Therefore ... 

The PR added the CompatVersionRecord which is an optional field that is defined as "A 32-bit number that identifies the Office Model version used by a VBA project." This record is optional and according to the OBVA documentation not written by VBA 5.0. Previously, if this record was found, the parser would simply panic. (There is another optional field ConstantsRecord, but this is at the end of the PROJECTINFORMATION record, therefore it didn't bother me).

The second minor change replaces the backslash to slash. This allows using `ovba` on Mac (and probably Linux). I ran the code on an M1 Mac and the two files I used for testing are created with MS365 on Mac.

A file which has this record can be found [here](https://github.com/JanMarvin/openxlsx-data/raw/refs/heads/main/gh_issue_416.xlsm), not sure anymore when or why this was created. Well this file loads now, and even works in my R rust package.

PS: I looked into your ovba-cli file, but this uses some Windows exclusive APIs and I couldn't convince ChatGPT to provide me with a drop in replacement for this.

PPS: Because I initially didn't know what caused the panic I updated the `cfb` crate to `0.10`, hoping that this might solve some hidden issue. Since I'm not aware how the dependency updates work, I left this out of the PR.